### PR TITLE
Generate Typescript 2.4 string enums

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/kiwi.js
+++ b/kiwi.js
@@ -2297,17 +2297,14 @@ var kiwi = exports || kiwi || {}, exports;
       var definition = schema.definitions[i];
 
       if (definition.kind === 'ENUM') {
-        lines.push(indent + 'export type ' + definition.name + ' =');
+        lines.push(indent + 'export enum ' + definition.name + ' {');
 
         for (var j = 0; j < definition.fields.length; j++) {
-          lines.push(indent + '  ' + JSON.stringify(definition.fields[j].name) + (j + 1 < definition.fields.length ? ' |' : ';'));
+          lines.push(indent + '  ' + definition.fields[j].name + ' = ' + JSON.stringify(definition.fields[j].name) + ',');
         }
 
-        if (!definition.fields.length) {
-          lines.push(indent + '  any;');
-        }
-
-        lines.push('');
+        lines.push(indent + '}');
+        lines.push('')
       }
     }
 

--- a/test/test-schema.ts
+++ b/test/test-schema.ts
@@ -1,7 +1,8 @@
 export namespace test {
-  export type Enum =
-    "A" |
-    "B";
+  export enum Enum {
+    A = "A",
+    B = "B",
+  }
 
   export interface EnumStruct {
     x: Enum;


### PR DESCRIPTION
Makes use of Typescript 2.4 string enums: https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-4.html.

Kiwi schema like this...

```
enum Cheese {
  swiss = 0;
  cheddar = 1;
  gouda = 2;
}
```

...generates Typescript types like this:

```typescript
export enum Cheese {
  swiss = 'swiss',
  cheddar = 'cheddar',
  gouda = 'gouda',
}
```