### PR TITLE
Make it safe to include kiwi.h multiple times in the same compilation unit w/ IMPLEMENT_KIWI_H

### DIFF
--- a/kiwi.h
+++ b/kiwi.h
@@ -172,6 +172,8 @@ namespace kiwi {
 
 #endif
 #ifdef IMPLEMENT_KIWI_H
+#ifndef IMPLEMENT_KIWI_H_
+#define IMPLEMENT_KIWI_H_
 
   kiwi::ByteBuffer::ByteBuffer() : _data(new uint8_t[INITIAL_CAPACITY]), _capacity(INITIAL_CAPACITY), _ownsData(true) {
   }
@@ -550,4 +552,5 @@ namespace kiwi {
     return true;
   }
 
+#endif
 #endif

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kiwi-schema",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "A schema-based binary format for efficiently encoding trees of data",
   "license": "MIT",
   "main": "kiwi.js",

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -12,6 +12,10 @@
 #define IMPLEMENT_KIWI_H
 #include "kiwi.h"
 
+// Include a second time to test that it's safe to include the kiwi header
+// multiple times in the same compilatinon unit
+#include "kiwi.h"
+
 static bool readFile(const char *path, kiwi::ByteBuffer &bb) {
   if (FILE *f = fopen(path, "rb")) {
     int c;


### PR DESCRIPTION
Ran `npm run test`.

Before this change, a bunch of linker warnings were emitted like this:

```
In file included from ./test.cpp:17:
../kiwi.h:176:21: error: redefinition of 'ByteBuffer'
  kiwi::ByteBuffer::ByteBuffer() : _data(new uint8_t[INITIAL_CAPACITY]), _capacity(INITIAL_CAPACITY), _ownsData(true) {
                    ^
```

After this change, no linker errors.

(Though `npm run test` exited with a return code of 0 in both cases...?)