### PR TITLE
Throw an error is we encounter an unknown enum value while decoding (JS)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+.vscode

--- a/test/test-schema.h
+++ b/test/test-schema.h
@@ -8,6 +8,7 @@ namespace test {
 class BinarySchema {
 public:
   bool parse(kiwi::ByteBuffer &bb);
+  bool skipEnumMessageField(kiwi::ByteBuffer &bb, uint32_t id) const;
   bool skipBoolMessageField(kiwi::ByteBuffer &bb, uint32_t id) const;
   bool skipByteMessageField(kiwi::ByteBuffer &bb, uint32_t id) const;
   bool skipIntMessageField(kiwi::ByteBuffer &bb, uint32_t id) const;
@@ -16,6 +17,7 @@ public:
   bool skipStringMessageField(kiwi::ByteBuffer &bb, uint32_t id) const;
   bool skipCompoundMessageField(kiwi::ByteBuffer &bb, uint32_t id) const;
   bool skipNestedMessageField(kiwi::ByteBuffer &bb, uint32_t id) const;
+  bool skipEnumArrayMessageField(kiwi::ByteBuffer &bb, uint32_t id) const;
   bool skipBoolArrayMessageField(kiwi::ByteBuffer &bb, uint32_t id) const;
   bool skipByteArrayMessageField(kiwi::ByteBuffer &bb, uint32_t id) const;
   bool skipIntArrayMessageField(kiwi::ByteBuffer &bb, uint32_t id) const;
@@ -29,6 +31,7 @@ public:
 
 private:
   kiwi::BinarySchema _schema;
+  uint32_t _indexEnumMessage = 0;
   uint32_t _indexBoolMessage = 0;
   uint32_t _indexByteMessage = 0;
   uint32_t _indexIntMessage = 0;
@@ -37,6 +40,7 @@ private:
   uint32_t _indexStringMessage = 0;
   uint32_t _indexCompoundMessage = 0;
   uint32_t _indexNestedMessage = 0;
+  uint32_t _indexEnumArrayMessage = 0;
   uint32_t _indexBoolArrayMessage = 0;
   uint32_t _indexByteArrayMessage = 0;
   uint32_t _indexIntArrayMessage = 0;
@@ -63,6 +67,7 @@ class FloatStruct;
 class StringStruct;
 class CompoundStruct;
 class NestedStruct;
+class EnumMessage;
 class BoolMessage;
 class ByteMessage;
 class IntMessage;
@@ -71,6 +76,7 @@ class FloatMessage;
 class StringMessage;
 class CompoundMessage;
 class NestedMessage;
+class EnumArrayStruct;
 class BoolArrayStruct;
 class ByteArrayStruct;
 class IntArrayStruct;
@@ -78,6 +84,7 @@ class UintArrayStruct;
 class FloatArrayStruct;
 class StringArrayStruct;
 class CompoundArrayStruct;
+class EnumArrayMessage;
 class BoolArrayMessage;
 class ByteArrayMessage;
 class IntArrayMessage;
@@ -254,6 +261,22 @@ private:
   uint32_t _data_c = {};
 };
 
+class EnumMessage {
+public:
+  EnumMessage() { (void)_flags; }
+
+  Enum *x();
+  const Enum *x() const;
+  void set_x(const Enum &value);
+
+  bool encode(kiwi::ByteBuffer &bb);
+  bool decode(kiwi::ByteBuffer &bb, kiwi::MemoryPool &pool, const BinarySchema *schema = nullptr);
+
+private:
+  uint32_t _flags[1] = {};
+  Enum _data_x = {};
+};
+
 class BoolMessage {
 public:
   BoolMessage() { (void)_flags; }
@@ -397,6 +420,22 @@ private:
   uint32_t _data_c = {};
 };
 
+class EnumArrayStruct {
+public:
+  EnumArrayStruct() { (void)_flags; }
+
+  kiwi::Array<Enum> *x();
+  const kiwi::Array<Enum> *x() const;
+  kiwi::Array<Enum> &set_x(kiwi::MemoryPool &pool, uint32_t count);
+
+  bool encode(kiwi::ByteBuffer &bb);
+  bool decode(kiwi::ByteBuffer &bb, kiwi::MemoryPool &pool, const BinarySchema *schema = nullptr);
+
+private:
+  uint32_t _flags[1] = {};
+  kiwi::Array<Enum> _data_x = {};
+};
+
 class BoolArrayStruct {
 public:
   BoolArrayStruct() { (void)_flags; }
@@ -512,6 +551,22 @@ private:
   uint32_t _flags[1] = {};
   kiwi::Array<uint32_t> _data_x = {};
   kiwi::Array<uint32_t> _data_y = {};
+};
+
+class EnumArrayMessage {
+public:
+  EnumArrayMessage() { (void)_flags; }
+
+  kiwi::Array<Enum> *x();
+  const kiwi::Array<Enum> *x() const;
+  kiwi::Array<Enum> &set_x(kiwi::MemoryPool &pool, uint32_t count);
+
+  bool encode(kiwi::ByteBuffer &bb);
+  bool decode(kiwi::ByteBuffer &bb, kiwi::MemoryPool &pool, const BinarySchema *schema = nullptr);
+
+private:
+  uint32_t _flags[1] = {};
+  kiwi::Array<Enum> _data_x = {};
 };
 
 class BoolArrayMessage {
@@ -830,6 +885,7 @@ private:
 
 bool BinarySchema::parse(kiwi::ByteBuffer &bb) {
   if (!_schema.parse(bb)) return false;
+  _schema.findDefinition("EnumMessage", _indexEnumMessage);
   _schema.findDefinition("BoolMessage", _indexBoolMessage);
   _schema.findDefinition("ByteMessage", _indexByteMessage);
   _schema.findDefinition("IntMessage", _indexIntMessage);
@@ -838,6 +894,7 @@ bool BinarySchema::parse(kiwi::ByteBuffer &bb) {
   _schema.findDefinition("StringMessage", _indexStringMessage);
   _schema.findDefinition("CompoundMessage", _indexCompoundMessage);
   _schema.findDefinition("NestedMessage", _indexNestedMessage);
+  _schema.findDefinition("EnumArrayMessage", _indexEnumArrayMessage);
   _schema.findDefinition("BoolArrayMessage", _indexBoolArrayMessage);
   _schema.findDefinition("ByteArrayMessage", _indexByteArrayMessage);
   _schema.findDefinition("IntArrayMessage", _indexIntArrayMessage);
@@ -849,6 +906,10 @@ bool BinarySchema::parse(kiwi::ByteBuffer &bb) {
   _schema.findDefinition("NonDeprecatedMessage", _indexNonDeprecatedMessage);
   _schema.findDefinition("DeprecatedMessage", _indexDeprecatedMessage);
   return true;
+}
+
+bool BinarySchema::skipEnumMessageField(kiwi::ByteBuffer &bb, uint32_t id) const {
+  return _schema.skipField(bb, _indexEnumMessage, id);
 }
 
 bool BinarySchema::skipBoolMessageField(kiwi::ByteBuffer &bb, uint32_t id) const {
@@ -881,6 +942,10 @@ bool BinarySchema::skipCompoundMessageField(kiwi::ByteBuffer &bb, uint32_t id) c
 
 bool BinarySchema::skipNestedMessageField(kiwi::ByteBuffer &bb, uint32_t id) const {
   return _schema.skipField(bb, _indexNestedMessage, id);
+}
+
+bool BinarySchema::skipEnumArrayMessageField(kiwi::ByteBuffer &bb, uint32_t id) const {
+  return _schema.skipField(bb, _indexEnumArrayMessage, id);
 }
 
 bool BinarySchema::skipBoolArrayMessageField(kiwi::ByteBuffer &bb, uint32_t id) const {
@@ -1203,6 +1268,47 @@ bool NestedStruct::decode(kiwi::ByteBuffer &_bb, kiwi::MemoryPool &_pool, const 
   if (!_bb.readVarUint(_data_c)) return false;
   set_c(_data_c);
   return true;
+}
+
+Enum *EnumMessage::x() {
+  return _flags[0] & 1 ? &_data_x : nullptr;
+}
+
+const Enum *EnumMessage::x() const {
+  return _flags[0] & 1 ? &_data_x : nullptr;
+}
+
+void EnumMessage::set_x(const Enum &value) {
+  _flags[0] |= 1; _data_x = value;
+}
+
+bool EnumMessage::encode(kiwi::ByteBuffer &_bb) {
+  if (x() != nullptr) {
+    _bb.writeVarUint(1);
+    _bb.writeVarUint(static_cast<uint32_t>(_data_x));
+  }
+  _bb.writeVarUint(0);
+  return true;
+}
+
+bool EnumMessage::decode(kiwi::ByteBuffer &_bb, kiwi::MemoryPool &_pool, const BinarySchema *_schema) {
+  while (true) {
+    uint32_t _type;
+    if (!_bb.readVarUint(_type)) return false;
+    switch (_type) {
+      case 0:
+        return true;
+      case 1: {
+        if (!_bb.readVarUint(reinterpret_cast<uint32_t &>(_data_x))) return false;
+        set_x(_data_x);
+        break;
+      }
+      default: {
+        if (!_schema || !_schema->skipEnumMessageField(_bb, _type)) return false;
+        break;
+      }
+    }
+  }
 }
 
 bool *BoolMessage::x() {
@@ -1596,6 +1702,32 @@ bool NestedMessage::decode(kiwi::ByteBuffer &_bb, kiwi::MemoryPool &_pool, const
   }
 }
 
+kiwi::Array<Enum> *EnumArrayStruct::x() {
+  return _flags[0] & 1 ? &_data_x : nullptr;
+}
+
+const kiwi::Array<Enum> *EnumArrayStruct::x() const {
+  return _flags[0] & 1 ? &_data_x : nullptr;
+}
+
+kiwi::Array<Enum> &EnumArrayStruct::set_x(kiwi::MemoryPool &pool, uint32_t count) {
+  _flags[0] |= 1; return _data_x = pool.array<Enum>(count);
+}
+
+bool EnumArrayStruct::encode(kiwi::ByteBuffer &_bb) {
+  if (x() == nullptr) return false;
+  _bb.writeVarUint(_data_x.size());
+  for (Enum &_it : _data_x) _bb.writeVarUint(static_cast<uint32_t>(_it));
+  return true;
+}
+
+bool EnumArrayStruct::decode(kiwi::ByteBuffer &_bb, kiwi::MemoryPool &_pool, const BinarySchema *_schema) {
+  uint32_t _count;
+  if (!_bb.readVarUint(_count)) return false;
+  for (Enum &_it : set_x(_pool, _count)) if (!_bb.readVarUint(reinterpret_cast<uint32_t &>(_it))) return false;
+  return true;
+}
+
 kiwi::Array<bool> *BoolArrayStruct::x() {
   return _flags[0] & 1 ? &_data_x : nullptr;
 }
@@ -1793,6 +1925,49 @@ bool CompoundArrayStruct::decode(kiwi::ByteBuffer &_bb, kiwi::MemoryPool &_pool,
   if (!_bb.readVarUint(_count)) return false;
   for (uint32_t &_it : set_y(_pool, _count)) if (!_bb.readVarUint(_it)) return false;
   return true;
+}
+
+kiwi::Array<Enum> *EnumArrayMessage::x() {
+  return _flags[0] & 1 ? &_data_x : nullptr;
+}
+
+const kiwi::Array<Enum> *EnumArrayMessage::x() const {
+  return _flags[0] & 1 ? &_data_x : nullptr;
+}
+
+kiwi::Array<Enum> &EnumArrayMessage::set_x(kiwi::MemoryPool &pool, uint32_t count) {
+  _flags[0] |= 1; return _data_x = pool.array<Enum>(count);
+}
+
+bool EnumArrayMessage::encode(kiwi::ByteBuffer &_bb) {
+  if (x() != nullptr) {
+    _bb.writeVarUint(1);
+    _bb.writeVarUint(_data_x.size());
+    for (Enum &_it : _data_x) _bb.writeVarUint(static_cast<uint32_t>(_it));
+  }
+  _bb.writeVarUint(0);
+  return true;
+}
+
+bool EnumArrayMessage::decode(kiwi::ByteBuffer &_bb, kiwi::MemoryPool &_pool, const BinarySchema *_schema) {
+  uint32_t _count;
+  while (true) {
+    uint32_t _type;
+    if (!_bb.readVarUint(_type)) return false;
+    switch (_type) {
+      case 0:
+        return true;
+      case 1: {
+        if (!_bb.readVarUint(_count)) return false;
+        for (Enum &_it : set_x(_pool, _count)) if (!_bb.readVarUint(reinterpret_cast<uint32_t &>(_it))) return false;
+        break;
+      }
+      default: {
+        if (!_schema || !_schema->skipEnumArrayMessageField(_bb, _type)) return false;
+        break;
+      }
+    }
+  }
 }
 
 kiwi::Array<bool> *BoolArrayMessage::x() {

--- a/test/test-schema.js
+++ b/test/test-schema.js
@@ -13,10 +13,18 @@ test["decodeEnumStruct"] = function(bb) {
     bb = new this.ByteBuffer(bb);
   }
 
-  result["x"] = this["Enum"][bb.readVarUint()];
+  result["x"] = (function (t) {
+  var byte = bb.readVarUint();
+  if (undefined == t["Enum"][byte]) { throw new Error("Attempted to parse invalid enum"); }
+  return t["Enum"][byte];
+})(this);
   var values = result["y"] = [];
   var length = bb.readVarUint();
-  while (length-- > 0) values.push(this["Enum"][bb.readVarUint()]);
+  while (length-- > 0) { values.push((function (t) {
+  var byte = bb.readVarUint();
+  if (undefined == t["Enum"][byte]) { throw new Error("Attempted to parse invalid enum"); }
+  return t["Enum"][byte];
+})(this)); }
   return result;
 };
 
@@ -258,6 +266,45 @@ test["encodeNestedStruct"] = function(message, bb) {
   } else {
     throw new Error("Missing required field \"c\"");
   }
+
+  if (isTopLevel) return bb.toUint8Array();
+};
+
+test["decodeEnumMessage"] = function(bb) {
+  var result = {};
+  if (!(bb instanceof this.ByteBuffer)) {
+    bb = new this.ByteBuffer(bb);
+  }
+
+  while (true) {
+    switch (bb.readVarUint()) {
+    case 0:
+      return result;
+
+    case 1:
+      result["x"] = (function (t) {
+  var byte = bb.readVarUint();
+  if (undefined == t["Enum"][byte]) { throw new Error("Attempted to parse invalid enum"); }
+  return t["Enum"][byte];
+})(this);
+      break;
+
+    default:
+      throw new Error("Attempted to parse invalid message");
+    }
+  }
+};
+
+test["encodeEnumMessage"] = function(message, bb) {
+  var isTopLevel = !bb;
+  if (isTopLevel) bb = new this.ByteBuffer();
+
+  var value = message["x"];
+  if (value != null) {
+    bb.writeVarUint(1);
+    var encoded = this["Enum"][value]; if (encoded === void 0) throw new Error("Invalid value " + JSON.stringify(value) + " for enum \"Enum\""); bb.writeVarUint(encoded);
+  }
+  bb.writeVarUint(0);
 
   if (isTopLevel) return bb.toUint8Array();
 };
@@ -572,6 +619,41 @@ test["encodeNestedMessage"] = function(message, bb) {
   if (isTopLevel) return bb.toUint8Array();
 };
 
+test["decodeEnumArrayStruct"] = function(bb) {
+  var result = {};
+  if (!(bb instanceof this.ByteBuffer)) {
+    bb = new this.ByteBuffer(bb);
+  }
+
+  var values = result["x"] = [];
+  var length = bb.readVarUint();
+  while (length-- > 0) { values.push((function (t) {
+  var byte = bb.readVarUint();
+  if (undefined == t["Enum"][byte]) { throw new Error("Attempted to parse invalid enum"); }
+  return t["Enum"][byte];
+})(this)); }
+  return result;
+};
+
+test["encodeEnumArrayStruct"] = function(message, bb) {
+  var isTopLevel = !bb;
+  if (isTopLevel) bb = new this.ByteBuffer();
+
+  var value = message["x"];
+  if (value != null) {
+    var values = value, n = values.length;
+    bb.writeVarUint(n);
+    for (var i = 0; i < n; i++) {
+      value = values[i];
+      var encoded = this["Enum"][value]; if (encoded === void 0) throw new Error("Invalid value " + JSON.stringify(value) + " for enum \"Enum\""); bb.writeVarUint(encoded);
+    }
+  } else {
+    throw new Error("Missing required field \"x\"");
+  }
+
+  if (isTopLevel) return bb.toUint8Array();
+};
+
 test["decodeBoolArrayStruct"] = function(bb) {
   var result = {};
   if (!(bb instanceof this.ByteBuffer)) {
@@ -580,7 +662,7 @@ test["decodeBoolArrayStruct"] = function(bb) {
 
   var values = result["x"] = [];
   var length = bb.readVarUint();
-  while (length-- > 0) values.push(!!bb.readByte());
+  while (length-- > 0) { values.push(!!bb.readByte()); }
   return result;
 };
 
@@ -611,7 +693,7 @@ test["decodeByteArrayStruct"] = function(bb) {
 
   var values = result["x"] = [];
   var length = bb.readVarUint();
-  while (length-- > 0) values.push(bb.readByte());
+  while (length-- > 0) { values.push(bb.readByte()); }
   return result;
 };
 
@@ -642,7 +724,7 @@ test["decodeIntArrayStruct"] = function(bb) {
 
   var values = result["x"] = [];
   var length = bb.readVarUint();
-  while (length-- > 0) values.push(bb.readVarInt());
+  while (length-- > 0) { values.push(bb.readVarInt()); }
   return result;
 };
 
@@ -673,7 +755,7 @@ test["decodeUintArrayStruct"] = function(bb) {
 
   var values = result["x"] = [];
   var length = bb.readVarUint();
-  while (length-- > 0) values.push(bb.readVarUint());
+  while (length-- > 0) { values.push(bb.readVarUint()); }
   return result;
 };
 
@@ -704,7 +786,7 @@ test["decodeFloatArrayStruct"] = function(bb) {
 
   var values = result["x"] = [];
   var length = bb.readVarUint();
-  while (length-- > 0) values.push(bb.readVarFloat());
+  while (length-- > 0) { values.push(bb.readVarFloat()); }
   return result;
 };
 
@@ -735,7 +817,7 @@ test["decodeStringArrayStruct"] = function(bb) {
 
   var values = result["x"] = [];
   var length = bb.readVarUint();
-  while (length-- > 0) values.push(bb.readString());
+  while (length-- > 0) { values.push(bb.readString()); }
   return result;
 };
 
@@ -766,10 +848,10 @@ test["decodeCompoundArrayStruct"] = function(bb) {
 
   var values = result["x"] = [];
   var length = bb.readVarUint();
-  while (length-- > 0) values.push(bb.readVarUint());
+  while (length-- > 0) { values.push(bb.readVarUint()); }
   var values = result["y"] = [];
   var length = bb.readVarUint();
-  while (length-- > 0) values.push(bb.readVarUint());
+  while (length-- > 0) { values.push(bb.readVarUint()); }
   return result;
 };
 
@@ -804,6 +886,52 @@ test["encodeCompoundArrayStruct"] = function(message, bb) {
   if (isTopLevel) return bb.toUint8Array();
 };
 
+test["decodeEnumArrayMessage"] = function(bb) {
+  var result = {};
+  if (!(bb instanceof this.ByteBuffer)) {
+    bb = new this.ByteBuffer(bb);
+  }
+
+  while (true) {
+    switch (bb.readVarUint()) {
+    case 0:
+      return result;
+
+    case 1:
+      var values = result["x"] = [];
+      var length = bb.readVarUint();
+      while (length-- > 0) { values.push((function (t) {
+  var byte = bb.readVarUint();
+  if (undefined == t["Enum"][byte]) { throw new Error("Attempted to parse invalid enum"); }
+  return t["Enum"][byte];
+})(this)); }
+      break;
+
+    default:
+      throw new Error("Attempted to parse invalid message");
+    }
+  }
+};
+
+test["encodeEnumArrayMessage"] = function(message, bb) {
+  var isTopLevel = !bb;
+  if (isTopLevel) bb = new this.ByteBuffer();
+
+  var value = message["x"];
+  if (value != null) {
+    bb.writeVarUint(1);
+    var values = value, n = values.length;
+    bb.writeVarUint(n);
+    for (var i = 0; i < n; i++) {
+      value = values[i];
+      var encoded = this["Enum"][value]; if (encoded === void 0) throw new Error("Invalid value " + JSON.stringify(value) + " for enum \"Enum\""); bb.writeVarUint(encoded);
+    }
+  }
+  bb.writeVarUint(0);
+
+  if (isTopLevel) return bb.toUint8Array();
+};
+
 test["decodeBoolArrayMessage"] = function(bb) {
   var result = {};
   if (!(bb instanceof this.ByteBuffer)) {
@@ -818,7 +946,7 @@ test["decodeBoolArrayMessage"] = function(bb) {
     case 1:
       var values = result["x"] = [];
       var length = bb.readVarUint();
-      while (length-- > 0) values.push(!!bb.readByte());
+      while (length-- > 0) { values.push(!!bb.readByte()); }
       break;
 
     default:
@@ -860,7 +988,7 @@ test["decodeByteArrayMessage"] = function(bb) {
     case 1:
       var values = result["x"] = [];
       var length = bb.readVarUint();
-      while (length-- > 0) values.push(bb.readByte());
+      while (length-- > 0) { values.push(bb.readByte()); }
       break;
 
     default:
@@ -902,7 +1030,7 @@ test["decodeIntArrayMessage"] = function(bb) {
     case 1:
       var values = result["x"] = [];
       var length = bb.readVarUint();
-      while (length-- > 0) values.push(bb.readVarInt());
+      while (length-- > 0) { values.push(bb.readVarInt()); }
       break;
 
     default:
@@ -944,7 +1072,7 @@ test["decodeUintArrayMessage"] = function(bb) {
     case 1:
       var values = result["x"] = [];
       var length = bb.readVarUint();
-      while (length-- > 0) values.push(bb.readVarUint());
+      while (length-- > 0) { values.push(bb.readVarUint()); }
       break;
 
     default:
@@ -986,7 +1114,7 @@ test["decodeFloatArrayMessage"] = function(bb) {
     case 1:
       var values = result["x"] = [];
       var length = bb.readVarUint();
-      while (length-- > 0) values.push(bb.readVarFloat());
+      while (length-- > 0) { values.push(bb.readVarFloat()); }
       break;
 
     default:
@@ -1028,7 +1156,7 @@ test["decodeStringArrayMessage"] = function(bb) {
     case 1:
       var values = result["x"] = [];
       var length = bb.readVarUint();
-      while (length-- > 0) values.push(bb.readString());
+      while (length-- > 0) { values.push(bb.readString()); }
       break;
 
     default:
@@ -1070,13 +1198,13 @@ test["decodeCompoundArrayMessage"] = function(bb) {
     case 1:
       var values = result["x"] = [];
       var length = bb.readVarUint();
-      while (length-- > 0) values.push(bb.readVarUint());
+      while (length-- > 0) { values.push(bb.readVarUint()); }
       break;
 
     case 2:
       var values = result["y"] = [];
       var length = bb.readVarUint();
-      while (length-- > 0) values.push(bb.readVarUint());
+      while (length-- > 0) { values.push(bb.readVarUint()); }
       break;
 
     default:
@@ -1172,13 +1300,13 @@ test["decodeNonDeprecatedMessage"] = function(bb) {
     case 3:
       var values = result["c"] = [];
       var length = bb.readVarUint();
-      while (length-- > 0) values.push(bb.readVarUint());
+      while (length-- > 0) { values.push(bb.readVarUint()); }
       break;
 
     case 4:
       var values = result["d"] = [];
       var length = bb.readVarUint();
-      while (length-- > 0) values.push(bb.readVarUint());
+      while (length-- > 0) { values.push(bb.readVarUint()); }
       break;
 
     case 5:
@@ -1281,12 +1409,12 @@ test["decodeDeprecatedMessage"] = function(bb) {
     case 3:
       var values = result["c"] = [];
       var length = bb.readVarUint();
-      while (length-- > 0) values.push(bb.readVarUint());
+      while (length-- > 0) { values.push(bb.readVarUint()); }
       break;
 
     case 4:
       var length = bb.readVarUint();
-      while (length-- > 0) bb.readVarUint();
+      while (length-- > 0) { bb.readVarUint() };
       break;
 
     case 5:
@@ -1364,22 +1492,22 @@ test["decodeSortedStruct"] = function(bb) {
   result["f2"] = bb.readString();
   var values = result["a3"] = [];
   var length = bb.readVarUint();
-  while (length-- > 0) values.push(!!bb.readByte());
+  while (length-- > 0) { values.push(!!bb.readByte()); }
   var values = result["b3"] = [];
   var length = bb.readVarUint();
-  while (length-- > 0) values.push(bb.readByte());
+  while (length-- > 0) { values.push(bb.readByte()); }
   var values = result["c3"] = [];
   var length = bb.readVarUint();
-  while (length-- > 0) values.push(bb.readVarInt());
+  while (length-- > 0) { values.push(bb.readVarInt()); }
   var values = result["d3"] = [];
   var length = bb.readVarUint();
-  while (length-- > 0) values.push(bb.readVarUint());
+  while (length-- > 0) { values.push(bb.readVarUint()); }
   var values = result["e3"] = [];
   var length = bb.readVarUint();
-  while (length-- > 0) values.push(bb.readVarFloat());
+  while (length-- > 0) { values.push(bb.readVarFloat()); }
   var values = result["f3"] = [];
   var length = bb.readVarUint();
-  while (length-- > 0) values.push(bb.readString());
+  while (length-- > 0) { values.push(bb.readString()); }
   return result;
 };
 

--- a/test/test-schema.kiwi
+++ b/test/test-schema.kiwi
@@ -6,7 +6,6 @@ enum Enum {
 }
 
 struct EnumStruct { Enum x; Enum[] y; }
-
 struct BoolStruct { bool x; }
 struct ByteStruct { byte x; }
 struct IntStruct { int x; }
@@ -16,6 +15,7 @@ struct StringStruct { string x; }
 struct CompoundStruct { uint x; uint y; }
 struct NestedStruct { uint a; CompoundStruct b; uint c; }
 
+message EnumMessage { Enum x = 1; }
 message BoolMessage { bool x = 1; }
 message ByteMessage { byte x = 1; }
 message IntMessage { int x = 1; }
@@ -25,6 +25,7 @@ message StringMessage { string x = 1; }
 message CompoundMessage { uint x = 1; uint y = 2; }
 message NestedMessage { uint a = 1; CompoundMessage b = 2; uint c = 3; }
 
+struct EnumArrayStruct { Enum[] x; }
 struct BoolArrayStruct { bool[] x; }
 struct ByteArrayStruct { byte[] x; }
 struct IntArrayStruct { int[] x; }
@@ -33,6 +34,7 @@ struct FloatArrayStruct { float[] x; }
 struct StringArrayStruct { string[] x; }
 struct CompoundArrayStruct { uint[] x; uint[] y; }
 
+message EnumArrayMessage { Enum[] x = 1; }
 message BoolArrayMessage { bool[] x = 1; }
 message ByteArrayMessage { byte[] x = 1; }
 message IntArrayMessage { int[] x = 1; }

--- a/test/test-schema.sk
+++ b/test/test-schema.sk
@@ -1,6 +1,7 @@
 namespace test {
   class BinarySchema {
     var _schema = Kiwi.BinarySchema.new
+    var _indexEnumMessage = 0
     var _indexBoolMessage = 0
     var _indexByteMessage = 0
     var _indexIntMessage = 0
@@ -9,6 +10,7 @@ namespace test {
     var _indexStringMessage = 0
     var _indexCompoundMessage = 0
     var _indexNestedMessage = 0
+    var _indexEnumArrayMessage = 0
     var _indexBoolArrayMessage = 0
     var _indexByteArrayMessage = 0
     var _indexIntArrayMessage = 0
@@ -22,6 +24,7 @@ namespace test {
 
     def parse(bytes Uint8Array) {
       _schema.parse(Kiwi.ByteBuffer.new(bytes))
+      _indexEnumMessage = _schema.findDefinition("EnumMessage")
       _indexBoolMessage = _schema.findDefinition("BoolMessage")
       _indexByteMessage = _schema.findDefinition("ByteMessage")
       _indexIntMessage = _schema.findDefinition("IntMessage")
@@ -30,6 +33,7 @@ namespace test {
       _indexStringMessage = _schema.findDefinition("StringMessage")
       _indexCompoundMessage = _schema.findDefinition("CompoundMessage")
       _indexNestedMessage = _schema.findDefinition("NestedMessage")
+      _indexEnumArrayMessage = _schema.findDefinition("EnumArrayMessage")
       _indexBoolArrayMessage = _schema.findDefinition("BoolArrayMessage")
       _indexByteArrayMessage = _schema.findDefinition("ByteArrayMessage")
       _indexIntArrayMessage = _schema.findDefinition("IntArrayMessage")
@@ -40,6 +44,10 @@ namespace test {
       _indexRecursiveMessage = _schema.findDefinition("RecursiveMessage")
       _indexNonDeprecatedMessage = _schema.findDefinition("NonDeprecatedMessage")
       _indexDeprecatedMessage = _schema.findDefinition("DeprecatedMessage")
+    }
+
+    def skipEnumMessageField(bb Kiwi.ByteBuffer, id int) {
+      _schema.skipField(bb, _indexEnumMessage, id)
     }
 
     def skipBoolMessageField(bb Kiwi.ByteBuffer, id int) {
@@ -72,6 +80,10 @@ namespace test {
 
     def skipNestedMessageField(bb Kiwi.ByteBuffer, id int) {
       _schema.skipField(bb, _indexNestedMessage, id)
+    }
+
+    def skipEnumArrayMessageField(bb Kiwi.ByteBuffer, id int) {
+      _schema.skipField(bb, _indexEnumArrayMessage, id)
     }
 
     def skipBoolArrayMessageField(bb Kiwi.ByteBuffer, id int) {
@@ -637,6 +649,72 @@ namespace test {
       self.a = bb.readVarUint
       self.b = CompoundStruct.decode(bb, schema)
       self.c = bb.readVarUint
+      return self
+    }
+  }
+
+  class EnumMessage {
+    var _flags0 = 0
+    var _x Enum = .A
+
+    def has_x bool {
+      return (_flags0 & 1) != 0
+    }
+
+    def x Enum {
+      assert(has_x)
+      return _x
+    }
+
+    def x=(value Enum) {
+      _x = value
+      _flags0 |= 1
+    }
+
+    def encode(bb Kiwi.ByteBuffer) {
+      if has_x {
+        bb.writeVarUint(1)
+        bb.writeVarUint(Enum.encode(_x))
+      }
+
+      bb.writeVarUint(0)
+    }
+
+    def encode Uint8Array {
+      var bb = Kiwi.ByteBuffer.new
+      encode(bb)
+      return bb.toUint8Array
+    }
+  }
+
+  namespace EnumMessage {
+    def decode(bytes Uint8Array) EnumMessage {
+      return decode(Kiwi.ByteBuffer.new(bytes), null)
+    }
+
+    def decode(bytes Uint8Array, schema BinarySchema) EnumMessage {
+      return decode(Kiwi.ByteBuffer.new(bytes), schema)
+    }
+
+    def decode(bb Kiwi.ByteBuffer, schema BinarySchema) EnumMessage {
+      var self = new
+      while true {
+        var type = bb.readVarUint
+        switch type {
+          case 0 {
+            break
+          }
+
+          case 1 {
+            self.x = Enum.decode(bb.readVarUint)
+          }
+
+          default {
+            if schema == null { Kiwi.DecodeError.throwInvalidMessage }
+            else { schema.skipEnumMessageField(bb, type) }
+          }
+        }
+      }
       return self
     }
   }
@@ -1241,6 +1319,60 @@ namespace test {
     }
   }
 
+  class EnumArrayStruct {
+    var _flags0 = 0
+    var _x List<Enum> = null
+
+    def has_x bool {
+      return (_flags0 & 1) != 0
+    }
+
+    def x List<Enum> {
+      assert(has_x)
+      return _x
+    }
+
+    def x=(value List<Enum>) {
+      _x = value
+      _flags0 |= 1
+    }
+
+    def encode(bb Kiwi.ByteBuffer) {
+      assert(has_x)
+      bb.writeVarUint(_x.count)
+      for value in _x {
+        bb.writeVarUint(Enum.encode(value))
+      }
+    }
+
+    def encode Uint8Array {
+      var bb = Kiwi.ByteBuffer.new
+      encode(bb)
+      return bb.toUint8Array
+    }
+  }
+
+  namespace EnumArrayStruct {
+    def decode(bytes Uint8Array) EnumArrayStruct {
+      return decode(Kiwi.ByteBuffer.new(bytes), null)
+    }
+
+    def decode(bytes Uint8Array, schema BinarySchema) EnumArrayStruct {
+      return decode(Kiwi.ByteBuffer.new(bytes), schema)
+    }
+
+    def decode(bb Kiwi.ByteBuffer, schema BinarySchema) EnumArrayStruct {
+      var self = new
+      var count = 0
+      count = bb.readVarUint
+      self.x = []
+      for array = self._x; count != 0; count-- {
+        array.append(Enum.decode(bb.readVarUint))
+      }
+      return self
+    }
+  }
+
   class BoolArrayStruct {
     var _flags0 = 0
     var _x List<bool> = null
@@ -1640,6 +1772,80 @@ namespace test {
       self.y = []
       for array = self._y; count != 0; count-- {
         array.append(bb.readVarUint)
+      }
+      return self
+    }
+  }
+
+  class EnumArrayMessage {
+    var _flags0 = 0
+    var _x List<Enum> = null
+
+    def has_x bool {
+      return (_flags0 & 1) != 0
+    }
+
+    def x List<Enum> {
+      assert(has_x)
+      return _x
+    }
+
+    def x=(value List<Enum>) {
+      _x = value
+      _flags0 |= 1
+    }
+
+    def encode(bb Kiwi.ByteBuffer) {
+      if has_x {
+        bb.writeVarUint(1)
+        bb.writeVarUint(_x.count)
+        for value in _x {
+          bb.writeVarUint(Enum.encode(value))
+        }
+      }
+
+      bb.writeVarUint(0)
+    }
+
+    def encode Uint8Array {
+      var bb = Kiwi.ByteBuffer.new
+      encode(bb)
+      return bb.toUint8Array
+    }
+  }
+
+  namespace EnumArrayMessage {
+    def decode(bytes Uint8Array) EnumArrayMessage {
+      return decode(Kiwi.ByteBuffer.new(bytes), null)
+    }
+
+    def decode(bytes Uint8Array, schema BinarySchema) EnumArrayMessage {
+      return decode(Kiwi.ByteBuffer.new(bytes), schema)
+    }
+
+    def decode(bb Kiwi.ByteBuffer, schema BinarySchema) EnumArrayMessage {
+      var self = new
+      var count = 0
+      while true {
+        var type = bb.readVarUint
+        switch type {
+          case 0 {
+            break
+          }
+
+          case 1 {
+            count = bb.readVarUint
+            self.x = []
+            for array = self._x; count != 0; count-- {
+              array.append(Enum.decode(bb.readVarUint))
+            }
+          }
+
+          default {
+            if schema == null { Kiwi.DecodeError.throwInvalidMessage }
+            else { schema.skipEnumArrayMessageField(bb, type) }
+          }
+        }
       }
       return self
     }

--- a/test/test-schema.ts
+++ b/test/test-schema.ts
@@ -43,6 +43,10 @@ export namespace test {
     c: number;
   }
 
+  export interface EnumMessage {
+    x?: Enum;
+  }
+
   export interface BoolMessage {
     x?: boolean;
   }
@@ -78,6 +82,10 @@ export namespace test {
     c?: number;
   }
 
+  export interface EnumArrayStruct {
+    x: Enum[];
+  }
+
   export interface BoolArrayStruct {
     x: boolean[];
   }
@@ -105,6 +113,10 @@ export namespace test {
   export interface CompoundArrayStruct {
     x: number[];
     y: number[];
+  }
+
+  export interface EnumArrayMessage {
+    x?: Enum[];
   }
 
   export interface BoolArrayMessage {
@@ -197,6 +209,8 @@ export namespace test {
     decodeCompoundStruct(buffer: Uint8Array): CompoundStruct;
     encodeNestedStruct(message: NestedStruct): Uint8Array;
     decodeNestedStruct(buffer: Uint8Array): NestedStruct;
+    encodeEnumMessage(message: EnumMessage): Uint8Array;
+    decodeEnumMessage(buffer: Uint8Array): EnumMessage;
     encodeBoolMessage(message: BoolMessage): Uint8Array;
     decodeBoolMessage(buffer: Uint8Array): BoolMessage;
     encodeByteMessage(message: ByteMessage): Uint8Array;
@@ -213,6 +227,8 @@ export namespace test {
     decodeCompoundMessage(buffer: Uint8Array): CompoundMessage;
     encodeNestedMessage(message: NestedMessage): Uint8Array;
     decodeNestedMessage(buffer: Uint8Array): NestedMessage;
+    encodeEnumArrayStruct(message: EnumArrayStruct): Uint8Array;
+    decodeEnumArrayStruct(buffer: Uint8Array): EnumArrayStruct;
     encodeBoolArrayStruct(message: BoolArrayStruct): Uint8Array;
     decodeBoolArrayStruct(buffer: Uint8Array): BoolArrayStruct;
     encodeByteArrayStruct(message: ByteArrayStruct): Uint8Array;
@@ -227,6 +243,8 @@ export namespace test {
     decodeStringArrayStruct(buffer: Uint8Array): StringArrayStruct;
     encodeCompoundArrayStruct(message: CompoundArrayStruct): Uint8Array;
     decodeCompoundArrayStruct(buffer: Uint8Array): CompoundArrayStruct;
+    encodeEnumArrayMessage(message: EnumArrayMessage): Uint8Array;
+    decodeEnumArrayMessage(buffer: Uint8Array): EnumArrayMessage;
     encodeBoolArrayMessage(message: BoolArrayMessage): Uint8Array;
     decodeBoolArrayMessage(buffer: Uint8Array): BoolArrayMessage;
     encodeByteArrayMessage(message: ByteArrayMessage): Uint8Array;

--- a/test/test.js
+++ b/test/test.js
@@ -129,6 +129,20 @@ it('struct nested', function() {
   check({a: 534, b: {x: 12345, y: 54321}, c: 321}, [150, 4, 185, 96, 177, 168, 3, 193, 2]);
 });
 
+it('message enum', function () {
+  function check(i, o) {
+    assert.deepEqual(Buffer(schema.encodeEnumMessage(i)), Buffer(o));
+    assert.deepEqual(schema.decodeEnumMessage(new Uint8Array(o)), i);
+  }
+
+  check({}, [0])
+  check({ x: 'A' }, [1, 100, 0])
+
+  assert.throws(function () {
+    schema.decodeEnumMessage(new Uint8Array([1, 300, 0]))
+  }, Error)
+})
+
 it('message bool', function() {
   function check(i, o) {
     assert.deepEqual(Buffer(schema.encodeBoolMessage(i)), Buffer(o));
@@ -215,6 +229,27 @@ it('message nested', function() {
   check({b: {x: 5, y: 6}}, [2, 1, 5, 2, 6, 0, 0]);
   check({b: {x: 5}, c: 123}, [2, 1, 5, 0, 3, 123, 0]);
   check({c: 123, b: {x: 5, y: 6}, a: 234}, [1, 234, 1, 2, 1, 5, 2, 6, 0, 3, 123, 0]);
+});
+
+it('struct enum array', function () {
+  function check(i, o) {
+    assert.deepEqual(Buffer(schema.encodeEnumArrayStruct({ x: i })), Buffer(o));
+    assert.deepEqual(schema.decodeEnumArrayStruct(new Uint8Array(o)), { x: i });
+  }
+
+  check([], [0]);
+  check(['B', 'A'], [2, 200, 1, 100]);
+});
+
+it('message enum array', function () {
+  function check(i, o) {
+    assert.deepEqual(Buffer(schema.encodeEnumArrayMessage(i)), Buffer(o));
+    assert.deepEqual(schema.decodeEnumArrayMessage(new Uint8Array(o)), i);
+  }
+
+  check({}, [0]);
+  check({ x: [] }, [1, 0, 0]);
+  check({ x: ['B', 'A'] }, [1, 2, 200, 1, 100, 0]);
 });
 
 it('struct bool array', function() {


### PR DESCRIPTION
Fixes https://github.com/evanw/kiwi/issues/11 and adds some missing enum tests.

In the javascript library, while decoding, Kiwi will throw an error if it encounters an field it doesn't know about.  It won't, however, throw an error if it encounters an Enum value it doesn't know about.  The decoded value will simply be `undefined`.

