### PR TITLE
optimize byte array encoding and decoding

### DIFF
--- a/js/kiwi.js
+++ b/js/kiwi.js
@@ -58,7 +58,7 @@ var kiwi = exports || kiwi || {}, exports;
     }
     this._index = end;
     // Copy into a new array instead of just creating another view.
-    var result = new Uint8Array();
+    var result = new Uint8Array(length);
     result.set(this._data.subarray(start, end));
     return result;
   };

--- a/js/kiwi.js
+++ b/js/kiwi.js
@@ -769,7 +769,7 @@ var kiwi = exports || kiwi || {}, exports;
       if (field.isArray) {
         if (field.isDeprecated) {
           lines.push(indent + 'var length = bb.readVarUint();');
-          if (field.type == 'byte') {
+          if (field.type === 'byte') {
             lines.push(indent + 'bb.readByteArray(length);');
           } else {
             lines.push(indent + 'while (length-- > 0) ' + code + ';');

--- a/test/test-schema.js
+++ b/test/test-schema.js
@@ -14,8 +14,8 @@ test["decodeEnumStruct"] = function(bb) {
   }
 
   result["x"] = this["Enum"][bb.readVarUint()];
-  var values = result["y"] = [];
   var length = bb.readVarUint();
+  var values = result["y"] = [];
   while (length-- > 0) values.push(this["Enum"][bb.readVarUint()]);
   return result;
 };
@@ -578,8 +578,8 @@ test["decodeBoolArrayStruct"] = function(bb) {
     bb = new this.ByteBuffer(bb);
   }
 
-  var values = result["x"] = [];
   var length = bb.readVarUint();
+  var values = result["x"] = [];
   while (length-- > 0) values.push(!!bb.readByte());
   return result;
 };
@@ -609,9 +609,8 @@ test["decodeByteArrayStruct"] = function(bb) {
     bb = new this.ByteBuffer(bb);
   }
 
-  var values = result["x"] = [];
   var length = bb.readVarUint();
-  while (length-- > 0) values.push(bb.readByte());
+  result["x"] = bb.readByteArray(length);
   return result;
 };
 
@@ -640,8 +639,8 @@ test["decodeIntArrayStruct"] = function(bb) {
     bb = new this.ByteBuffer(bb);
   }
 
-  var values = result["x"] = [];
   var length = bb.readVarUint();
+  var values = result["x"] = [];
   while (length-- > 0) values.push(bb.readVarInt());
   return result;
 };
@@ -671,8 +670,8 @@ test["decodeUintArrayStruct"] = function(bb) {
     bb = new this.ByteBuffer(bb);
   }
 
-  var values = result["x"] = [];
   var length = bb.readVarUint();
+  var values = result["x"] = [];
   while (length-- > 0) values.push(bb.readVarUint());
   return result;
 };
@@ -702,8 +701,8 @@ test["decodeFloatArrayStruct"] = function(bb) {
     bb = new this.ByteBuffer(bb);
   }
 
-  var values = result["x"] = [];
   var length = bb.readVarUint();
+  var values = result["x"] = [];
   while (length-- > 0) values.push(bb.readVarFloat());
   return result;
 };
@@ -733,8 +732,8 @@ test["decodeStringArrayStruct"] = function(bb) {
     bb = new this.ByteBuffer(bb);
   }
 
-  var values = result["x"] = [];
   var length = bb.readVarUint();
+  var values = result["x"] = [];
   while (length-- > 0) values.push(bb.readString());
   return result;
 };
@@ -764,11 +763,11 @@ test["decodeCompoundArrayStruct"] = function(bb) {
     bb = new this.ByteBuffer(bb);
   }
 
+  var length = bb.readVarUint();
   var values = result["x"] = [];
-  var length = bb.readVarUint();
   while (length-- > 0) values.push(bb.readVarUint());
-  var values = result["y"] = [];
   var length = bb.readVarUint();
+  var values = result["y"] = [];
   while (length-- > 0) values.push(bb.readVarUint());
   return result;
 };
@@ -816,8 +815,8 @@ test["decodeBoolArrayMessage"] = function(bb) {
       return result;
 
     case 1:
-      var values = result["x"] = [];
       var length = bb.readVarUint();
+      var values = result["x"] = [];
       while (length-- > 0) values.push(!!bb.readByte());
       break;
 
@@ -858,9 +857,8 @@ test["decodeByteArrayMessage"] = function(bb) {
       return result;
 
     case 1:
-      var values = result["x"] = [];
       var length = bb.readVarUint();
-      while (length-- > 0) values.push(bb.readByte());
+      result["x"] = bb.readByteArray(length);
       break;
 
     default:
@@ -900,8 +898,8 @@ test["decodeIntArrayMessage"] = function(bb) {
       return result;
 
     case 1:
-      var values = result["x"] = [];
       var length = bb.readVarUint();
+      var values = result["x"] = [];
       while (length-- > 0) values.push(bb.readVarInt());
       break;
 
@@ -942,8 +940,8 @@ test["decodeUintArrayMessage"] = function(bb) {
       return result;
 
     case 1:
-      var values = result["x"] = [];
       var length = bb.readVarUint();
+      var values = result["x"] = [];
       while (length-- > 0) values.push(bb.readVarUint());
       break;
 
@@ -984,8 +982,8 @@ test["decodeFloatArrayMessage"] = function(bb) {
       return result;
 
     case 1:
-      var values = result["x"] = [];
       var length = bb.readVarUint();
+      var values = result["x"] = [];
       while (length-- > 0) values.push(bb.readVarFloat());
       break;
 
@@ -1026,8 +1024,8 @@ test["decodeStringArrayMessage"] = function(bb) {
       return result;
 
     case 1:
-      var values = result["x"] = [];
       var length = bb.readVarUint();
+      var values = result["x"] = [];
       while (length-- > 0) values.push(bb.readString());
       break;
 
@@ -1068,14 +1066,14 @@ test["decodeCompoundArrayMessage"] = function(bb) {
       return result;
 
     case 1:
-      var values = result["x"] = [];
       var length = bb.readVarUint();
+      var values = result["x"] = [];
       while (length-- > 0) values.push(bb.readVarUint());
       break;
 
     case 2:
-      var values = result["y"] = [];
       var length = bb.readVarUint();
+      var values = result["y"] = [];
       while (length-- > 0) values.push(bb.readVarUint());
       break;
 
@@ -1170,14 +1168,14 @@ test["decodeNonDeprecatedMessage"] = function(bb) {
       break;
 
     case 3:
-      var values = result["c"] = [];
       var length = bb.readVarUint();
+      var values = result["c"] = [];
       while (length-- > 0) values.push(bb.readVarUint());
       break;
 
     case 4:
-      var values = result["d"] = [];
       var length = bb.readVarUint();
+      var values = result["d"] = [];
       while (length-- > 0) values.push(bb.readVarUint());
       break;
 
@@ -1279,8 +1277,8 @@ test["decodeDeprecatedMessage"] = function(bb) {
       break;
 
     case 3:
-      var values = result["c"] = [];
       var length = bb.readVarUint();
+      var values = result["c"] = [];
       while (length-- > 0) values.push(bb.readVarUint());
       break;
 
@@ -1362,23 +1360,22 @@ test["decodeSortedStruct"] = function(bb) {
   result["d2"] = bb.readVarUint();
   result["e2"] = bb.readVarFloat();
   result["f2"] = bb.readString();
+  var length = bb.readVarUint();
   var values = result["a3"] = [];
-  var length = bb.readVarUint();
   while (length-- > 0) values.push(!!bb.readByte());
-  var values = result["b3"] = [];
   var length = bb.readVarUint();
-  while (length-- > 0) values.push(bb.readByte());
+  result["b3"] = bb.readByteArray(length);
+  var length = bb.readVarUint();
   var values = result["c3"] = [];
-  var length = bb.readVarUint();
   while (length-- > 0) values.push(bb.readVarInt());
+  var length = bb.readVarUint();
   var values = result["d3"] = [];
-  var length = bb.readVarUint();
   while (length-- > 0) values.push(bb.readVarUint());
+  var length = bb.readVarUint();
   var values = result["e3"] = [];
-  var length = bb.readVarUint();
   while (length-- > 0) values.push(bb.readVarFloat());
-  var values = result["f3"] = [];
   var length = bb.readVarUint();
+  var values = result["f3"] = [];
   while (length-- > 0) values.push(bb.readString());
   return result;
 };

--- a/test/test-schema.js
+++ b/test/test-schema.js
@@ -620,12 +620,8 @@ test["encodeByteArrayStruct"] = function(message, bb) {
 
   var value = message["x"];
   if (value != null) {
-    var values = value, n = values.length;
-    bb.writeVarUint(n);
-    for (var i = 0; i < n; i++) {
-      value = values[i];
-      bb.writeByte(value);
-    }
+    bb.writeVarUint(value.length);
+    bb.writeByteArray(value);
   } else {
     throw new Error("Missing required field \"x\"");
   }
@@ -874,12 +870,8 @@ test["encodeByteArrayMessage"] = function(message, bb) {
   var value = message["x"];
   if (value != null) {
     bb.writeVarUint(1);
-    var values = value, n = values.length;
-    bb.writeVarUint(n);
-    for (var i = 0; i < n; i++) {
-      value = values[i];
-      bb.writeByte(value);
-    }
+    bb.writeVarUint(value.length);
+    bb.writeByteArray(value);
   }
   bb.writeVarUint(0);
 
@@ -1482,12 +1474,8 @@ test["encodeSortedStruct"] = function(message, bb) {
 
   var value = message["b3"];
   if (value != null) {
-    var values = value, n = values.length;
-    bb.writeVarUint(n);
-    for (var i = 0; i < n; i++) {
-      value = values[i];
-      bb.writeByte(value);
-    }
+    bb.writeVarUint(value.length);
+    bb.writeByteArray(value);
   } else {
     throw new Error("Missing required field \"b3\"");
   }

--- a/test/test.js
+++ b/test/test.js
@@ -150,6 +150,16 @@ it('message byte', function() {
   check({x: 234}, [1, 234, 0]);
 });
 
+it('struct byte array', function() {
+  function check(i, o) {
+    assert.deepEqual(Buffer(schema.encodeByteArrayStruct(i)), Buffer(o));
+    assert.deepEqual(schema.decodeByteArrayStruct(new Uint8Array(o)), i);
+  }
+
+  check({x: new Uint8Array()}, [0]);
+  check({x: new Uint8Array([4, 5, 6])}, [3, 4, 5, 6]);
+});
+
 it('message uint', function() {
   function check(i, o) {
     assert.deepEqual(Buffer(schema.encodeUintMessage(i)), Buffer(o));


### PR DESCRIPTION
Use typed `Uint8Array.set()` for encoding and decoding arrays of bytes. In the encoding case, this replaces byte-for-byte copying in a loop into a bulk `memcpy`-like operation. In the decoding case, this additionally uses 1/8 the amount of memory by avoiding use of generic Javascript array `[Number, Number, ...]` by copying into another typed `Uint8Array`.

Test plan:
- add a test to cover byte array struct encoding and decoding to test the new code paths
- manually validate that with these changes, a decoding operation that previously crashed the Chrome tab from OOM now loads successfully