### PR TITLE
Fix schema parser

### DIFF
--- a/kiwi.h
+++ b/kiwi.h
@@ -491,7 +491,7 @@ namespace kiwi {
             !bb.readVarInt(field.type) ||
             !bb.readByte(field.isArray) ||
             !bb.readVarUint(field.value) ||
-            field.type < TYPE_STRING ||
+            field.type < TYPE_UINT64 ||
             field.type >= (int32_t)definitionCount) {
           return false;
         }


### PR DESCRIPTION
**Fixed**
-
- Schema parser fails if there are any of newly added fields `INT64` (-7) and `UINT64` (-8). Condition compares lower type than `STRING` (-6) and fails parsing. New field types are then considered as invalid.